### PR TITLE
Remove debugging statement

### DIFF
--- a/generate_parking_slots.py
+++ b/generate_parking_slots.py
@@ -218,8 +218,6 @@ def generate_parking_slots(sector):
                 id_number = j+1+skip
             elif numbering == "hop":
                 id_number = j*total_groups+1+skip
-            if id_number == 11 and sector_id == "test-":
-                print("YO")
                 
             save_polygon(sector["id"] + str(id_number),
                         [round(startY, 6), round(startX, 6)],  


### PR DESCRIPTION
## Summary
- remove leftover YO debugging print in generate_parking_slots

## Testing
- `python generate_parking_slots.py` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_6841a0d01704832e8e8114d03736a79d