### PR TITLE
Fix comment typo in parking slot generation script

### DIFF
--- a/generate_parking_slots.py
+++ b/generate_parking_slots.py
@@ -125,7 +125,7 @@ def generate_parking_slots(sector):
     layout = "normal" if "layout" not in sector else sector["layout"]
     parking_angle = 90
 
-    #schema: start - 0, end - 1, start2 - 2, mulitpoint - 3
+    #schema: start - 0, end - 1, start2 - 2, multipoint - 3
     config_data = {
         "sector_data": {
             "start": [],


### PR DESCRIPTION
## Summary
- correct a typo in the comment describing sector schema

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a16fbb98832e84222020262ea551